### PR TITLE
Added pod affinity if the default ReadWriteOnce is used.

### DIFF
--- a/templates/deployment-sidekiq.yaml
+++ b/templates/deployment-sidekiq.yaml
@@ -45,10 +45,26 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (default (default $context.Values.affinity $context.Values.mastodon.sidekiq.affinity) .affinity) }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- if (not $context.Values.mastodon.s3.enabled) }}
+        {{- if not (default $context.Values.affinity $context.Values.mastodon.sidekiq.affinity).podAffinity }}
+        {{- if or (eq "ReadWriteOnce" $context.Values.mastodon.persistence.assets.accessMode) (eq "ReadWriteOnce" $context.Values.mastodon.persistence.system.accessMode) }}
+        # the pods need to end up to the same node for ReadWriteOnce
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/part-of
+                    operator: In
+                    values:
+                      - rails
+              topologyKey: kubernetes.io/hostname
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with (default $context.Values.affinity $context.Values.mastodon.sidekiq.affinity) }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if (not $context.Values.mastodon.s3.enabled) }}
       volumes:
         - name: assets

--- a/templates/deployment-web.yaml
+++ b/templates/deployment-web.yaml
@@ -118,10 +118,26 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (default .Values.affinity .Values.mastodon.web.affinity) }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- if (not .Values.mastodon.s3.enabled) }}
+        {{- if not (default .Values.affinity .Values.mastodon.web.affinity).podAffinity }}
+        {{- if or (eq "ReadWriteOnce" .Values.mastodon.persistence.assets.accessMode) (eq "ReadWriteOnce" .Values.mastodon.persistence.system.accessMode) }}
+        # the pods need to end up to the same node for ReadWriteOnce
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/part-of
+                    operator: In
+                    values:
+                      - rails
+              topologyKey: kubernetes.io/hostname
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with (default .Values.affinity .Values.mastodon.web.affinity) }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
If `accessMode` `ReadWriteOnce` is used, then the volume can only be accessed in a write mode from a single node. This means that all pods which require write access to the volume need to be co-located to the same node. Failing that typically leads to a difficult to untangle locked volume mount situation where containers are stuck in `ContainerCreating`.

This change adds the necessary pod affinities if the related access modes are set in the `values.yaml`.